### PR TITLE
send response as fast as possible

### DIFF
--- a/server/routes/webhooks.js
+++ b/server/routes/webhooks.js
@@ -32,9 +32,9 @@ export default (storage) => {
     }
 
     // Deploy the changes.
-    return deploy(storage, id, project_id, branch, repository, sha, user, req.auth0)
-      .then(stats => res.status(200).json(stats))
-      .catch(next);
+    deploy(storage, id, project_id, branch, repository, sha, user, req.auth0);
+
+    return res.status(204).send();
   });
 
   return webhooks;


### PR DESCRIPTION
Should fix #17.
GitLab recommends: "Your endpoint should send its HTTP response as fast as possible. If
you wait too long, GitLab may decide the hook failed and retry it."