### PR TITLE
Scopes fix

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -43,7 +43,7 @@ module.exports = (configProvider, storageProvider) => {
     clientName: 'GitLab Deploy Extension',
     urlPrefix: '/admins',
     sessionStorageKey: 'gitlab-deploy:apiToken',
-    scopes: 'read:tenant_settings update:tenant_settings create:clients read:clients update:clients read:connections update:connections read:rules create:rules update:rules delete:rules delete:clients read:resource_servers create:resource_servers update:resource_servers read:rules_configs delete:rules_configs update:rules_configs'
+    scopes: 'read:tenant_settings update:tenant_settings create:clients read:clients update:clients read:client_grants create:client_grants update:client_grants read:connections update:connections read:rules create:rules update:rules delete:rules delete:clients read:resource_servers create:resource_servers update:resource_servers read:rules_configs delete:rules_configs update:rules_configs'
   }));
 
   // Configure routes.

--- a/webtask.json
+++ b/webtask.json
@@ -20,7 +20,7 @@
   "auth0": {
     "createClient": true,
     "onUninstallPath": "/.extensions/on-uninstall",
-    "scopes": "read:tenant_settings update:tenant_settings create:clients read:clients update:clients read:connections update:connections read:rules create:rules update:rules delete:rules delete:clients read:resource_servers create:resource_servers update:resource_servers read:rules_configs delete:rules_configs update:rules_configs"
+    "scopes": "read:tenant_settings update:tenant_settings create:clients read:clients update:clients read:client_grants create:client_grants update:client_grants read:connections update:connections read:rules create:rules update:rules delete:rules delete:clients read:resource_servers create:resource_servers update:resource_servers read:rules_configs delete:rules_configs update:rules_configs"
   },
   "secrets": {
     "GITLAB_REPOSITORY": {


### PR DESCRIPTION
## ✏️ Changes
We're added client grants support in latest version of `source-control-extension-tools`, but forgot to add client_grants scopes.
Simply added read, create and update client_grants scopes. `source-control-extension-tools` does not remove client grants.

## 🔗 References
Slack: https://auth0.slack.com/archives/C9HLEJL9W/p1535122347000100
Jira: https://auth0team.atlassian.net/browse/KEY-256