### PR TITLE
KEY-639: connection prop reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "externals": [
       "async@2.1.2",
       "auth0-extension-tools@1.3.2",
-      "auth0-source-control-extension-tools@3.0.9",
+      "auth0-source-control-extension-tools",
       "bluebird@3.4.6",
       "compression@1.4.4",
       "delegates@0.1.0",
@@ -77,7 +77,7 @@
     "auth0-extension-tools": "1.3.2",
     "auth0-extension-ui": "^1.0.1",
     "auth0-oauth2-express": "^1.1.8",
-    "auth0-source-control-extension-tools": "^3.0.9",
+    "auth0-source-control-extension-tools": "3.0.10",
     "axios": "^0.15.0",
     "babel": "^6.5.2",
     "babel-core": "^6.9.1",


### PR DESCRIPTION
## ✏️ Changes
Actual fix is in [source-control-extension-tools PR](https://github.com/auth0-extensions/auth0-source-control-extension-tools/pull/51)
  
## 🔗 References
  Jira: https://auth0team.atlassian.net/browse/KEY-639
  
## 🎯 Testing
✅ This change has been tested locally

## 🚀 Deployment
⚠️ This should not be merged until [source-control-extension-tools PR](https://github.com/auth0-extensions/auth0-source-control-extension-tools/pull/51) merged, published to npm and added to the webtask.