### PR TITLE
DB settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Ability to deploy db-connection settings by adding `/database-connections/[connection-name]/settings.json`.
+
 ## [2.6.0] - 2018-12-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ repository =>
     some other resource server.json
   database-connections
     my-connection-name
+      settings.json
       get_user.js
       login.js
   rules-configs

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "auth0-extension-tools": "1.3.2",
     "auth0-extension-ui": "^1.0.1",
     "auth0-oauth2-express": "^1.1.8",
-    "auth0-source-control-extension-tools": "3.0.10",
+    "auth0-source-control-extension-tools": "^3.0.10",
     "axios": "^0.15.0",
     "babel": "^6.5.2",
     "babel-core": "^6.9.1",

--- a/server/lib/gitlab.js
+++ b/server/lib/gitlab.js
@@ -175,7 +175,7 @@ const unifyData = (assets) => {
       result[type] = unifyItem(data, type);
     }
   });
-  console.log(result.databases);
+
   return result;
 };
 


### PR DESCRIPTION
## ✏️ Changes
Added possibility to read `settings.json` of database connection. It should be placed at `/database-connections/[connection-name]/settings.json`, it can contain any connection settings, including `options`. Options will be merged with `customScripts`, if db-scripts are provided.
  
## 🔗 References
Slack: https://auth0.slack.com/archives/C9170558S/p1544222234120100
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  